### PR TITLE
Add a .gitignore file for jekyll.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site/
+.sass-cache/
+.jekyll-metadata


### PR DESCRIPTION
If developers want to make adjustments locally, this will ensure they do not push ready-built files to this repo.