### PR TITLE
show clickable video thumbnail

### DIFF
--- a/sessions/introduction.md
+++ b/sessions/introduction.md
@@ -18,6 +18,4 @@ What you'll learn
 Video
 -----
 
-<div class="container">
-	<iframe id="ytplayer" type="text/html" width="640" height="360" src="https://www.youtube-nocookie.com/embed/zPYfT9azdK8?rel=0&autoplay=0&origin={{ site.url }}" frameborder="0"></iframe>
-</div>
+[![Introduction Video](https://img.youtube.com/vi/zPYfT9azdK8/0.jpg)](https://www.youtube.com/watch?v=zPYfT9azdK8)


### PR DESCRIPTION
Previously under the video tab on the introduction page, it would show html that looked like the following:
```html
<iframe id="ytplayer" type="text/html" width="640" height="360" src="https://www.youtube-nocookie.com/embed/zPYfT9azdK8?rel=0&autoplay=0&origin={{ site.url }}" frameborder="0"></iframe>
```

With this update we now show a thumbnail preview of the video instead of an html tag on the page.