### PR TITLE
Adding Hackboxes link to the nav bar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,6 +16,9 @@
           <a class="nav-link" href="https://ctf.hacker101.com/">CTF</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="https://www.hackerone.com/blog/Test-your-hacking-skills-real-world-simulated-bugs">HackBoxes</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ "/resources" | relative_url }}">Resources</a>
         </li>
       </ul>


### PR DESCRIPTION
This blog post seemed to be related to Hacker101 (it was tagged as such). I thought then it should be referenced from the nav bar or else incorporated into the instructions somewhere on the site: 

https://www.hackerone.com/blog/Test-your-hacking-skills-real-world-simulated-bugs