### PR TITLE
Move quick links to main resources body

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -1,9 +1,16 @@
 ---
 layout: page
 title: Resources
-sidebar:
-  - title: Jump to
-    resources: true
+---
+
+<ul>
+  {% for resource in site.resources %}
+    <li>
+      <a href="/resources#{{ resource.title | url_encode }}">{{ resource.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
 ---
 
 {% for resource in site.resources %}


### PR DESCRIPTION
This makes it easier for those on mobile to see the quick links at the start of the page.

<img width="358" alt="Screen Shot 2021-08-03 at 11 35 29 PM" src="https://user-images.githubusercontent.com/5761179/128133344-c7e29392-281b-4f6b-a0c6-c2a9d10e2530.png">
<img width="1155" alt="Screen Shot 2021-08-03 at 11 35 15 PM" src="https://user-images.githubusercontent.com/5761179/128133350-2e5fd248-a0b1-41fc-9693-4015c5698bed.png">
