### PR TITLE
fix: Add webrick dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
I was unable to serve these pages with jekyll locally, as webrick was missing. For reference, see: https://github.com/github/pages-gem/issues/752

This PR adds the webrick dependency.

I've confirmed I can now locally serve the pages again by running `bundle exec jekyll serve`
