### PR TITLE
Add sessions overview page

### DIFF
--- a/sessions/sessions.html
+++ b/sessions/sessions.html
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Sessions
+permalink: /sessions/
+---
+
+{% for child_page in site.pages %}
+    {% assign target_dir = 'sessions/' %}
+    {% if child_page.path contains target_dir and child_page.path != page.path %}
+        <li>
+            <a href="{{ child_page.url | relative_url }}">{{ child_page.title }}</a>
+        </li>
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
Similar to the `/playlists` overview that was recently added, this PR adds on overview of all sessions on `/sessions`.

## Preview

![Screenshot 2024-04-22 at 14 44 59](https://github.com/Hacker0x01/hacker101/assets/338470/8ac94463-5db0-4ddb-a410-68a1eea7a6fd)
