### PR TITLE
Fix typo meantal to mental

### DIFF
--- a/playlists/mentorshipmondays.md
+++ b/playlists/mentorshipmondays.md
@@ -17,7 +17,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/how_to_pentest
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
   - title: "Season 02"
     links:
       - text: "Getting Started in Bug Bounties"

--- a/sessions/mm/s01/ctf_vs_bugbounty.md
+++ b/sessions/mm/s01/ctf_vs_bugbounty.md
@@ -15,7 +15,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/how_to_pentest
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 previous_url: howtoshodan
 next_url: mobile_hacking
 video_src: https://www.youtube-nocookie.com/embed/leU8gPxX2bs

--- a/sessions/mm/s01/h1-elite.md
+++ b/sessions/mm/s01/h1-elite.md
@@ -15,7 +15,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/hacktivitycon
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 
 video_src: https://www.youtube-nocookie.com/embed/alf64qFhqwU
 next_url: hackthegovt

--- a/sessions/mm/s01/hackthegovt.md
+++ b/sessions/mm/s01/hackthegovt.md
@@ -15,7 +15,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/how_to_pentest
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 
 previous_url: h1-elite
 next_url: howtoshodan

--- a/sessions/mm/s01/how_to_pentest.md
+++ b/sessions/mm/s01/how_to_pentest.md
@@ -15,9 +15,9 @@ sidebar:
       - text: "Mobile Hacking"
         url: /sessions/mm/s01/mobile_hacking
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 previous_url: mobile_hacking
-next_url: meantalhealth
+next_url: mentalhealth
 video_src: https://www.youtube-nocookie.com/embed/QecaJ95HF0o
 ---
 

--- a/sessions/mm/s01/howtoshodan.md
+++ b/sessions/mm/s01/howtoshodan.md
@@ -17,7 +17,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/how_to_pentest
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 previous_url: hackthegovt
 next_url: ctf_vs_bugbounty
 video_src: https://www.youtube-nocookie.com/embed/XmXK0AR1KU8

--- a/sessions/mm/s01/mentalhealth.md
+++ b/sessions/mm/s01/mentalhealth.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Meantal Health for Hackers
+title: Mental Health for Hackers
 sidebar:
   - title: "Season 01"
     links:

--- a/sessions/mm/s01/mobile_hacking.md
+++ b/sessions/mm/s01/mobile_hacking.md
@@ -17,7 +17,7 @@ sidebar:
       - text: "How to Pentest"
         url: /sessions/mm/s01/how_to_pentest
       - text: "Mental Health for Hackers"
-        url: /sessions/mm/s01/meantalhealth
+        url: /sessions/mm/s01/mentalhealth
 previous_url: ctf_vs_bugbounty
 next_url: how_to_pentest
 video_src: https://www.youtube-nocookie.com/embed/eF2CqYEiw5k


### PR DESCRIPTION
I noticed a typo in the word Mental. 

Before: 
![image](https://github.com/Hacker0x01/hacker101/assets/23737561/d892b582-f84e-4e80-919d-afe64d0cfd5e)

After: 
![image](https://github.com/Hacker0x01/hacker101/assets/23737561/c2fe39d3-b1d3-4614-b658-51173d51a44a)
