### PR TITLE
Open CTF link in other tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,11 +23,11 @@
               Videos
             </a>
           </li>
-          <li class="nav-item">
-            <a href="https://ctf.hacker101.com/" class="nav-link text-light">
+            <li class="nav-item">
+            <a href="https://ctf.hacker101.com/" target="_blank" class="nav-link text-light">
               CTF
             </a>
-          </li>
+            </li>
           <li class="nav-item">
             <a href="{{ "/resources" | relative_url }}" class="nav-link text-light">
               Resources

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,11 +23,11 @@
               Videos
             </a>
           </li>
-            <li class="nav-item">
+          <li class="nav-item">
             <a href="https://ctf.hacker101.com/" target="_blank" class="nav-link text-light">
               CTF
             </a>
-            </li>
+          </li>
           <li class="nav-item">
             <a href="{{ "/resources" | relative_url }}" class="nav-link text-light">
               Resources


### PR DESCRIPTION
When you click on the CTF menu item on the header, the website currently directs you to that page in the same tab. I made a small change so that the website will now open in a new tab. 

![image](https://github.com/Hacker0x01/hacker101/assets/23737561/c2d6d708-50e1-4f1b-8b2b-dd113daaaa72)
