### PR TITLE
fix: indentation of "Javascript for hackers"

### DIFF
--- a/playlists/web_hacking.md
+++ b/playlists/web_hacking.md
@@ -3,14 +3,14 @@ layout: page
 title: Web Hacking
 ---
 
-This learning track is dedicated to learning the most popular web application vulnerabilities. 
+This learning track is dedicated to learning the most popular web application vulnerabilities.
 
 Lessons
 -----
 
 - [XSS and Authorization](/sessions/xss)
-  - [JavaScript for Hackers](/sessions/javascript_for_hackers)
-    <span class="badge badge-pill badge-secondary">New!</span>
+- [JavaScript for Hackers](/sessions/javascript_for_hackers)
+  <span class="badge badge-pill badge-secondary">New!</span>
 - [SQL Injection and Friends](/sessions/sqli)
 - [Session Fixation](/sessions/session_fixation)
 - [Clickjacking](/sessions/clickjacking)


### PR DESCRIPTION
Small fix on indentation of a list item.

## Before
![before](https://github.com/Hacker0x01/hacker101/assets/338470/cec04225-97d4-424a-b6ae-87e9d3ac12d8)

## After
![after](https://github.com/Hacker0x01/hacker101/assets/338470/baa6a18d-fe25-4ced-94ec-177ec764554c)
